### PR TITLE
Adding github user and email inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         INPUT_SEMVER: ${{ inputs.semver }}
     - name: Set dropdown options
       id: write
-      uses: ynput/gha-form-dropdown-options@main
+      uses: ShaMan123/gha-form-dropdown-options@v2.0.3
       with:
         github_token: ${{ inputs.github_token }}
         github_user: ${{ inputs.github_user }}

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,12 @@ inputs:
   github_token:
     description: Github token
     default: ${{ github.token }}
+  github_user:
+    description: Github user
+    default: github-actions[bot]
+  github_email:
+    description: Github email
+    default: github-actions[bot]@users.noreply.github.com
 
   package:
     description: |
@@ -131,7 +137,7 @@ runs:
         node ${{ github.action_path }}/dist/main.cjs
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_PACKAGE: ${{ inputs.package }}
         INPUT_REGISTRY: ${{ inputs.registry }}
         INPUT_ORDER: ${{ inputs.order }}
@@ -139,8 +145,11 @@ runs:
         INPUT_SEMVER: ${{ inputs.semver }}
     - name: Set dropdown options
       id: write
-      uses: ShaMan123/gha-form-dropdown-options@v2.0.3
+      uses: ynput/gha-form-dropdown-options@main
       with:
+        github_token: ${{ inputs.github_token }}
+        github_user: ${{ inputs.github_user }}
+        github_email: ${{ inputs.github_email }}
         template: ${{ inputs.template }}
         form: ${{ inputs.form }}
         dropdown: ${{ inputs.dropdown }}


### PR DESCRIPTION
# Description:

This pull-request adds two new inputs to the action.yml file: user and email. These inputs will allow users to specify the user name and email address associated with the commits made by the action.

This feature is particularly useful for actions that generate commits or perform other git operations. By including this information, it will be easier to track who made the changes and when they were made.

The user and email inputs are optional, but if they are not provided, the action will fall back to using the default user and email associated with the GitHub account that created the token.

Please review and let me know if any changes are needed. Thank you!